### PR TITLE
Use mimetypes-lib to detect mimetypes and add logic to detect uri-lists

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -292,11 +292,11 @@ class ResultStreamer(Thread):
                     if is_uri:
                         mimetype = "text/uri-list"
                     else: 
-                        mimetype = "text/octet-stream"
+                        mimetype = "text/plain"
                 elif mime[0] is not None:
                     mimetype = mime[0]
                 else:
-                    mimetype = "text/octet-stream"
+                    mimetype = "application/octet-stream"
                 with open(file_path, 'rb') as fh:
                     content = fh.read()
                 result["artifacts"].append(


### PR DESCRIPTION
Use different library to detect mimetypes, so that custom mimetypes, like the ViPLab-formats and  VTK-files, can also be added and detected.

Additionally add logic to detect files of type "text/uri-list", that are detected by the library as "text/plain".